### PR TITLE
fix channel name to number bug

### DIFF
--- a/js/tss/TssCompiler.js
+++ b/js/tss/TssCompiler.js
@@ -473,7 +473,7 @@ TssCompiler._checkChannelDirective = function (line) {
         index = n.alphabetIndex(offset++);
         if (index < 0)
             return;
-        channel = index * TssCompiler._ALPHABET_COUNT;
+        channel = (index + 1) * TssCompiler._ALPHABET_COUNT;
     }
     index = n.alphabetIndex(offset);
     if (index < 0)


### PR DESCRIPTION
I found a bug that #AA-#AZ channel number become same as #A-#Z.

The following is the test code:

    <!DOCTYPE html>
    <html lang="ja">
    <head>
        <meta charset="UTF-8">
        <title></title>
        <script type="text/javascript">var exports = {};</script>
        <script type="text/javascript" src="js/tss/TString.js"></script>
        <script type="text/javascript" src="js/tss/TssCompiler.js"></script>
    </head>
    <body>
        <script type="text/javascript">
            var line;

            line = {directive:'A'};
            TssCompiler._checkChannelDirective(line);
            console.assert(line.directive === 0); // expect 0, actual 0

            line = {directive:'Z'};
            TssCompiler._checkChannelDirective(line); // expect 25, actual 25
            console.assert(line.directive === 25);

            line = {directive:'AA'};
            TssCompiler._checkChannelDirective(line);
            console.assert(line.directive === 26); // expect 26 but actual value is 0

        </script>
    </body>
    </html>
