### PR TITLE
Fix Log.js `exports` not defined

### DIFF
--- a/js/Log.js
+++ b/js/Log.js
@@ -137,4 +137,6 @@ Log.prototype.info = function (message) {
     this.print(message);
 };
 
-exports.Log = Log;
+if (typeof exports !== 'undefined') {
+    exports.Log = Log;
+}


### PR DESCRIPTION
Fix Uncaught ReferenceError: exports is not defined
    at Log.js:140:1